### PR TITLE
Dispose the cancellationTokenSouce

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ public async Task RunCommandWithTimeout(string filename, string arguments, TimeS
     try
     {
         var processResults = await ProcessEx.RunAsync(processStartInfo, cancellationTokenSource.Token);
+        cancellationTokenSource.dispose();
     }
     catch (OperationCanceledException)
     {


### PR DESCRIPTION
Dispose the cancellationTokenSouce in order to prevent it from firing after Task is complete