### PR TITLE
Improved process wrap up on cancellation

### DIFF
--- a/src/RunProcessAsTask/ProcessEx.cs
+++ b/src/RunProcessAsTask/ProcessEx.cs
@@ -76,7 +76,7 @@ namespace RunProcessAsTask
             process.Exited += OnExited;
 
             using (cancellationToken.Register(
-                () => {
+                async () => {
                     try
                     {
                         if (!process.HasExited)
@@ -85,9 +85,10 @@ namespace RunProcessAsTask
                             process.ErrorDataReceived -= ErrorDataReceived;
                             process.Exited -= OnExited;
                             process.Kill();
-                            if (!process.WaitForExit(_processExitGraceTime.Milliseconds))
+                            await Task.Delay(TimeSpan.FromSeconds(1));
+                            if (!process.HasExited)
                             {
-                                if (!process.HasExited)
+                                if (!process.WaitForExit(_processExitGraceTime.Milliseconds))
                                 {
                                     throw new TimeoutException($"Timed out after {_processExitGraceTime.TotalSeconds:N2} seconds waiting for cancelled process to exit: {process}");
                                 }

--- a/src/RunProcessAsTask/ProcessEx.cs
+++ b/src/RunProcessAsTask/ProcessEx.cs
@@ -32,24 +32,33 @@ namespace RunProcessAsTask
             };
 
             var standardOutputResults = new TaskCompletionSource<string[]>();
-            process.OutputDataReceived += (sender, args) => {
+
+            void OutputDataReceived(object sender, DataReceivedEventArgs args)
+            {
                 if (args.Data != null)
                     standardOutput.Add(args.Data);
                 else
                     standardOutputResults.SetResult(standardOutput.ToArray());
-            };
+            }
+
+            process.OutputDataReceived += OutputDataReceived;
 
             var standardErrorResults = new TaskCompletionSource<string[]>();
-            process.ErrorDataReceived += (sender, args) => {
+
+            void ErrorDataReceived(object sender, DataReceivedEventArgs args)
+            {
                 if (args.Data != null)
                     standardError.Add(args.Data);
                 else
                     standardErrorResults.SetResult(standardError.ToArray());
-            };
+            }
+
+            process.ErrorDataReceived += ErrorDataReceived;
 
             var processStartTime = new TaskCompletionSource<DateTime>();
 
-            process.Exited += async (sender, args) => {
+            async void OnExited(object sender, EventArgs args)
+            {
                 // Since the Exited event can happen asynchronously to the output and error events, 
                 // we await the task results for stdout/stderr to ensure they both closed.  We must await
                 // the stdout/stderr tasks instead of just accessing the Result property due to behavior on MacOS.  
@@ -62,7 +71,9 @@ namespace RunProcessAsTask
                         await standardErrorResults.Task.ConfigureAwait(false)
                     )
                 );
-            };
+            }
+
+            process.Exited += OnExited;
 
             using (cancellationToken.Register(
                 () => {
@@ -70,10 +81,16 @@ namespace RunProcessAsTask
                     {
                         if (!process.HasExited)
                         {
+                            process.OutputDataReceived -= OutputDataReceived;
+                            process.ErrorDataReceived -= ErrorDataReceived;
+                            process.Exited -= OnExited;
                             process.Kill();
                             if (!process.WaitForExit(_processExitGraceTime.Milliseconds))
                             {
-                                throw new TimeoutException($"Timed out after {_processExitGraceTime.TotalSeconds:N2} seconds waiting for cancelled process to exit: {process}");
+                                if (!process.HasExited)
+                                {
+                                    throw new TimeoutException($"Timed out after {_processExitGraceTime.TotalSeconds:N2} seconds waiting for cancelled process to exit: {process}");
+                                }
                             }
                         }
                         tcs.TrySetCanceled();
@@ -83,7 +100,7 @@ namespace RunProcessAsTask
                     }
                     catch (Exception exception)
                     {
-                        tcs.SetException(new Exception($"Failed to kill process '{process}' upon cancellation", exception));
+                        tcs.SetException(new Exception($"Failed to kill process '{process.StartInfo.FileName}' ({process.Id}) upon cancellation", exception));
                     }
                 })) {
                 cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
* Only set cancellation source as cancelled when process had exit
* After killing process, wait with a timeout for actual termination
* If process termination failed, propagate the exception